### PR TITLE
Fixed variable reference error in full_items list generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Password list generator for password spraying - prebaked with goodies
   <img width=400px src="resources/spraygenlogo.png" />
 </p>
 
-**Version 1.6**
+**Version 1.7**
 
 Generates permutations of Months, Seasons, Years, Sports Teams (NFL, NBA, MLB, NHL), Sports Scores, "Password", and even Iterable Keyspaces of a specified size.
 
@@ -40,7 +40,7 @@ python3 spraygen.py -h
 
     Original Art by Alex Chudnovsky (Unaffiliated)
     Spraygen tool by 3ndG4me
-    Version 1.6
+    Version 1.7
     
 usage: spraygen.py [-h] [--year_start YEAR_START] [--year_end YEAR_END] [-s separators] [-a attributes] [-w wordlist] [-n single word] [--mode {all,nosep,noattr,years,plain,letter,quick,custom}]
                    [--type {all,iterative,sports,nfl,nba,mlb,nhl,months,seasons,password,common,short,custom} [{all,iterative,sports,nfl,nba,mlb,nhl,months,seasons,password,common,short,custom} ...]]

--- a/spraygen.py
+++ b/spraygen.py
@@ -400,7 +400,7 @@ def generate_keyspace_list(mode, size, year_start, year_end):
         bar.finish()
     elif mode == "full":
         full_items = list(itertools.product(full_keyspace, repeat=size))
-        bar = Bar(Fore.BLUE + "[*] Info: " + Style.RESET_ALL + "Generating " + mode + " keyspace list", suffix='%(percent)d%%', max=len(numspec_items))
+        bar = Bar(Fore.BLUE + "[*] Info: " + Style.RESET_ALL + "Generating " + mode + " keyspace list", suffix='%(percent)d%%', max=len(full_items))
         for item in full_items:
             update_spray_list(''.join(item))
             generate_years(''.join(item), year_start, year_end)
@@ -1129,7 +1129,7 @@ def main():
 
     Original Art by Alex Chudnovsky (Unaffiliated)
     Spraygen tool by 3ndG4me
-    Version 1.6
+    Version 1.7
     '''
 
     print(Fore.BLUE + banner + Style.RESET_ALL)


### PR DESCRIPTION
Line 403 referenced `numspec_items` incorrectly when it should have referenced `full_items` this caused a variable reference error which this PR fixes.